### PR TITLE
Fixed Issue#13 and bug in initializePool

### DIFF
--- a/logs/neat.log
+++ b/logs/neat.log
@@ -1,261 +1,33 @@
-TRACE   [15:25:33.346, 31.07.15]: ENTER de.kaping.model.Pool.initializePool()
-TRACE   [15:25:33.349, 31.07.15]:    Create new Neuron.
-TRACE   [15:25:33.349, 31.07.15]:    Create new Neuron.
-TRACE   [15:25:33.349, 31.07.15]:    Create new Neuron.
-TRACE   [15:25:33.349, 31.07.15]:    Create new Neuron.
-DEBUG   [15:25:33.350, 31.07.15]:   new Species!
-DEBUG   [15:25:33.351, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.351, 31.07.15]: new: 1 species: 0 diff: 0
-DEBUG   [15:25:33.351, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.351, 31.07.15]:    added
-DEBUG   [15:25:33.351, 31.07.15]: new: 1 species: 0 diff: 0
-DEBUG   [15:25:33.351, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.351, 31.07.15]:    added
-DEBUG   [15:25:33.351, 31.07.15]:    Neue Innovation!
-TRACE   [15:25:33.351, 31.07.15]:    Create new Neuron.
-DEBUG   [15:25:33.351, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.352, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.352, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.352, 31.07.15]: new: 2 species: 0 diff: 1
-DEBUG   [15:25:33.352, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.352, 31.07.15]:   new Species!
-DEBUG   [15:25:33.352, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.352, 31.07.15]: new: 1 species: 0 diff: 0
-DEBUG   [15:25:33.352, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.352, 31.07.15]:    added
-TRACE   [15:25:33.352, 31.07.15]:    Create new Neuron.
-DEBUG   [15:25:33.352, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.352, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.352, 31.07.15]: new: 1 species: 0 diff: 1
-DEBUG   [15:25:33.352, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.352, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.352, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.353, 31.07.15]:   new Species!
-DEBUG   [15:25:33.353, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.353, 31.07.15]: new: 1 species: 0 diff: 0
-DEBUG   [15:25:33.353, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.353, 31.07.15]:    added
-DEBUG   [15:25:33.353, 31.07.15]:    Neue Innovation!
-TRACE   [15:25:33.353, 31.07.15]:    Create new Neuron.
-DEBUG   [15:25:33.353, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.353, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.353, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.353, 31.07.15]: new: 2 species: 0 diff: 1
-DEBUG   [15:25:33.353, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.353, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.353, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.353, 31.07.15]: new: 2 species: 1 diff: 2
-DEBUG   [15:25:33.353, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.353, 31.07.15]:   new Species!
-DEBUG   [15:25:33.353, 31.07.15]:    Neue Innovation!
-TRACE   [15:25:33.353, 31.07.15]:    Create new Neuron.
-DEBUG   [15:25:33.353, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.353, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.354, 31.07.15]: new: 3 species: 0 diff: 3
-DEBUG   [15:25:33.354, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.354, 31.07.15]: new: 3 species: 2 diff: 3
-DEBUG   [15:25:33.354, 31.07.15]: deltaD: 0.03826493700554874, deltaW: 0.03826493700554874
-DEBUG   [15:25:33.354, 31.07.15]: new: 3 species: 1 diff: 4
-DEBUG   [15:25:33.354, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.354, 31.07.15]: new: 3 species: 2 diff: 5
-DEBUG   [15:25:33.354, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.354, 31.07.15]:   new Species!
-DEBUG   [15:25:33.354, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.354, 31.07.15]:    Neue Innovation!
-TRACE   [15:25:33.354, 31.07.15]:    Create new Neuron.
-DEBUG   [15:25:33.354, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.354, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.354, 31.07.15]: new: 2 species: 0 diff: 2
-DEBUG   [15:25:33.354, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.354, 31.07.15]: new: 2 species: 2 diff: 4
-DEBUG   [15:25:33.354, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]: new: 2 species: 1 diff: 3
-DEBUG   [15:25:33.355, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]: new: 2 species: 2 diff: 4
-DEBUG   [15:25:33.355, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]: new: 2 species: 3 diff: 5
-DEBUG   [15:25:33.355, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]:   new Species!
-DEBUG   [15:25:33.355, 31.07.15]: new: 2 species: 0 diff: 1
-DEBUG   [15:25:33.355, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.355, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]: new: 2 species: 1 diff: 2
-DEBUG   [15:25:33.355, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.355, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]: new: 2 species: 3 diff: 4
-DEBUG   [15:25:33.355, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.355, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.355, 31.07.15]:   new Species!
-DEBUG   [15:25:33.356, 31.07.15]:    Neue Innovation!
-TRACE   [15:25:33.356, 31.07.15]:    Create new Neuron.
-DEBUG   [15:25:33.356, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.356, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.356, 31.07.15]: new: 2 species: 0 diff: 2
-DEBUG   [15:25:33.356, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.356, 31.07.15]: new: 2 species: 2 diff: 2
-DEBUG   [15:25:33.356, 31.07.15]: deltaD: 0.7228367583479287, deltaW: 0.7228367583479287
-DEBUG   [15:25:33.356, 31.07.15]: new: 2 species: 1 diff: 3
-DEBUG   [15:25:33.356, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.356, 31.07.15]: new: 2 species: 2 diff: 4
-DEBUG   [15:25:33.356, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.356, 31.07.15]: new: 2 species: 3 diff: 5
-DEBUG   [15:25:33.356, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.356, 31.07.15]: new: 2 species: 2 diff: 4
-DEBUG   [15:25:33.356, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.356, 31.07.15]: new: 2 species: 2 diff: 4
-DEBUG   [15:25:33.356, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.357, 31.07.15]:   new Species!
-DEBUG   [15:25:33.357, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.357, 31.07.15]: new: 1 species: 0 diff: 0
-DEBUG   [15:25:33.357, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.357, 31.07.15]:    added
-DEBUG   [15:25:33.357, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.357, 31.07.15]: new: 2 species: 0 diff: 1
-DEBUG   [15:25:33.358, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.358, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.358, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.358, 31.07.15]: new: 2 species: 1 diff: 2
-DEBUG   [15:25:33.358, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.358, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.358, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.358, 31.07.15]: new: 2 species: 3 diff: 2
-DEBUG   [15:25:33.358, 31.07.15]: deltaD: 0.9099289030045474, deltaW: 0.9099289030045474
-DEBUG   [15:25:33.358, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.358, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.359, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.359, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.359, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.359, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.359, 31.07.15]:   new Species!
-DEBUG   [15:25:33.359, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.359, 31.07.15]: new: 1 species: 0 diff: 0
-DEBUG   [15:25:33.359, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.359, 31.07.15]:    added
-DEBUG   [15:25:33.359, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.359, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.359, 31.07.15]: new: 3 species: 0 diff: 2
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.360, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.360, 31.07.15]: new: 3 species: 1 diff: 3
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.360, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.360, 31.07.15]: new: 3 species: 3 diff: 5
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.360, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.360, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.360, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.360, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.360, 31.07.15]:   new Species!
-DEBUG   [15:25:33.360, 31.07.15]: new: 1 species: 0 diff: 1
-DEBUG   [15:25:33.360, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.361, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 1 diff: 2
-DEBUG   [15:25:33.361, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.361, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 3 diff: 4
-DEBUG   [15:25:33.361, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.361, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.361, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.361, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.361, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 3 diff: 3
-DEBUG   [15:25:33.361, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.361, 31.07.15]:   new Species!
-DEBUG   [15:25:33.361, 31.07.15]: new: 1 species: 0 diff: 1
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 1 diff: 2
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 3 diff: 4
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 2 diff: 3
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 3 diff: 3
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]: new: 1 species: 1 diff: 2
-DEBUG   [15:25:33.362, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.362, 31.07.15]:   new Species!
-DEBUG   [15:25:33.363, 31.07.15]:    Neue Innovation!
-TRACE   [15:25:33.363, 31.07.15]:    Create new Neuron.
-DEBUG   [15:25:33.363, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.363, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.363, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.363, 31.07.15]: new: 3 species: 0 diff: 2
-DEBUG   [15:25:33.363, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.363, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.363, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.363, 31.07.15]: new: 3 species: 1 diff: 3
-DEBUG   [15:25:33.363, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.363, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.363, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.363, 31.07.15]: new: 3 species: 3 diff: 5
-DEBUG   [15:25:33.364, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.364, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.364, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.364, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.364, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.364, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.364, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.364, 31.07.15]: new: 3 species: 2 diff: 4
-DEBUG   [15:25:33.364, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.364, 31.07.15]: new: 3 species: 3 diff: 5
-DEBUG   [15:25:33.364, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.364, 31.07.15]: new: 3 species: 1 diff: 3
-DEBUG   [15:25:33.364, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.364, 31.07.15]: new: 3 species: 1 diff: 3
-DEBUG   [15:25:33.364, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.364, 31.07.15]:   new Species!
-DEBUG   [15:25:33.364, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.364, 31.07.15]:    Neue Innovation!
-DEBUG   [15:25:33.365, 31.07.15]: new: 2 species: 0 diff: 1
-DEBUG   [15:25:33.365, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.365, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.365, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.365, 31.07.15]: new: 2 species: 1 diff: 2
-DEBUG   [15:25:33.365, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.365, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.365, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.365, 31.07.15]: new: 2 species: 3 diff: 4
-DEBUG   [15:25:33.365, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.365, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.365, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.365, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.365, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.365, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.365, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.365, 31.07.15]: new: 2 species: 2 diff: 3
-DEBUG   [15:25:33.365, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.366, 31.07.15]: new: 2 species: 3 diff: 4
-DEBUG   [15:25:33.366, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.366, 31.07.15]: new: 2 species: 1 diff: 2
-DEBUG   [15:25:33.366, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.366, 31.07.15]: new: 2 species: 1 diff: 2
-DEBUG   [15:25:33.366, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.366, 31.07.15]: new: 2 species: 3 diff: 4
-DEBUG   [15:25:33.366, 31.07.15]: deltaD: 0.0, deltaW: 0.0
-DEBUG   [15:25:33.366, 31.07.15]:   new Species!
-TRACE   [15:25:33.366, 31.07.15]:  EXIT de.kaping.model.Pool.initializePool()
+TRACE   [11:15:07.753, 03.08.15]: ENTER de.kaping.model.Pool.initializePool()
+TRACE   [11:15:07.756, 03.08.15]:    Create new Neuron.
+TRACE   [11:15:07.756, 03.08.15]:    Create new Neuron.
+TRACE   [11:15:07.756, 03.08.15]:    Create new Neuron.
+TRACE   [11:15:07.756, 03.08.15]:    Create new Neuron.
+DEBUG   [11:15:07.757, 03.08.15]:    new Link: -3 zu -4
+DEBUG   [11:15:07.757, 03.08.15]:    Neue Innovation!
+TRACE   [11:15:07.757, 03.08.15]:    Create new Neuron.
+DEBUG   [11:15:07.757, 03.08.15]:    adding new Neuron to this generation!
+DEBUG   [11:15:07.757, 03.08.15]:    new Link: -3 zu 1
+DEBUG   [11:15:07.757, 03.08.15]:    Neue Innovation!
+DEBUG   [11:15:07.757, 03.08.15]:    new Link: 1 zu -4
+DEBUG   [11:15:07.757, 03.08.15]:    Neue Innovation!
+DEBUG   [11:15:07.758, 03.08.15]:    new Link: -2 zu -4
+DEBUG   [11:15:07.758, 03.08.15]:    Neue Innovation!
+DEBUG   [11:15:07.758, 03.08.15]:    new Link: -1 zu -4
+DEBUG   [11:15:07.758, 03.08.15]:    Neue Innovation!
+TRACE   [11:15:07.758, 03.08.15]:    Create new Neuron.
+DEBUG   [11:15:07.758, 03.08.15]:    adding new Neuron to this generation!
+DEBUG   [11:15:07.758, 03.08.15]:    new Link: -2 zu 4
+DEBUG   [11:15:07.758, 03.08.15]:    Neue Innovation!
+DEBUG   [11:15:07.758, 03.08.15]:    new Link: 4 zu -4
+DEBUG   [11:15:07.758, 03.08.15]:    Neue Innovation!
+DEBUG   [11:15:07.759, 03.08.15]:    new Link: -3 zu 4
+DEBUG   [11:15:07.759, 03.08.15]:    Neue Innovation!
+TRACE   [11:15:07.759, 03.08.15]:    Create new Neuron.
+DEBUG   [11:15:07.759, 03.08.15]:    adding new Neuron to this generation!
+DEBUG   [11:15:07.759, 03.08.15]:    new Link: -1 zu 5
+DEBUG   [11:15:07.759, 03.08.15]:    Neue Innovation!
+DEBUG   [11:15:07.759, 03.08.15]:    new Link: 5 zu -4
+DEBUG   [11:15:07.759, 03.08.15]:    Neue Innovation!
+TRACE   [11:15:07.760, 03.08.15]:  EXIT de.kaping.model.Pool.initializePool()
+TRACE   [11:15:07.760, 03.08.15]: exit

--- a/src/de/kaping/model/Gene.java
+++ b/src/de/kaping/model/Gene.java
@@ -166,8 +166,7 @@ public class Gene implements Comparable<Gene>{
 	public boolean isEqual(Gene gene2)
 	{
 		if((this.origin == gene2.origin) && (this.into == gene2.into))
-			return true;
-		
+			return true;		
 		return false;
 	}
 

--- a/src/de/kaping/model/Genome.java
+++ b/src/de/kaping/model/Genome.java
@@ -404,8 +404,8 @@ public class Genome implements Comparable<Genome>{
 	private void mutateLink(boolean bias)
 	{
 		Random rn = new Random();
-		Neuron neuron1 = neurons.get(rn.nextInt(neurons.size()));
-		Neuron neuron2 = neurons.get(rn.nextInt(neurons.size()));
+		Neuron neuron1 = this.neurons.get(rn.nextInt(this.neurons.size()));
+		Neuron neuron2 = this.neurons.get(rn.nextInt(this.neurons.size()));
 		
 		Type t1 = neuron1.getType();
 		Type t2 = neuron2.getType();
@@ -414,12 +414,13 @@ public class Genome implements Comparable<Genome>{
 		
 		/* wenn beide zufälligen Neuronen Input oder Output sind, dann Abbruch */
 		if((t1==Type.INPUT || t1==Type.BIAS) && (t2==Type.INPUT || t2==Type.BIAS) 
-				|| t1 == Type.OUTPUT && t2 == Type.OUTPUT)
+				|| (t1 == Type.OUTPUT && t2 == Type.OUTPUT))
 			return;
 		
 		/* sollte ein Neuron Input sein, so soll es der Origin werden, ein 
 		 * Outputneuron sollte das Ziel werden */
-		if(neuron2.getType() == Type.INPUT || neuron1.getType() == Type.OUTPUT)
+		if(neuron2.getType() == Type.INPUT || neuron1.getType() == Type.OUTPUT 
+				|| neuron2.getType() == Type.BIAS)
 		{
 			origin = neuron2;
 			into   = neuron1;
@@ -453,21 +454,37 @@ public class Genome implements Comparable<Genome>{
 	{
 		Random rn = new Random();
 		Gene gene = genes.get(rn.nextInt(genes.size()));
+		Pool pool = Pool.getInstance();
+		boolean neuronExists = false;
 		
 		/* bei inaktiver Verbindung wird die Mutierung abgebrochen */
-		if(gene.getEnabled() == false)
+		if (gene.getEnabled() == false)
 		{
 			return;
 		}
 			
 		gene.setEnabled(false);
-		Neuron newNeuron = new Neuron(Type.HIDDEN);
+		
+		Neuron newNeuron = null;
+		for (Neuron n : pool.getNewNeurons())
+			if (n.getInnovation() == gene.getHistoricalMarking())
+			{
+				newNeuron = n;
+				neuronExists = true;
+				break;
+			}
+		
+		if (!neuronExists)
+		{
+			newNeuron = new Neuron(Type.HIDDEN, gene.getHistoricalMarking());
+			pool.addNewNeuron(newNeuron);
+		}
 		
 		Gene newGene1 = new Gene(gene.getOrigin(), newNeuron, 1.0);
 		Gene newGene2 = new Gene(newNeuron, gene.getInto(), gene.getWeight());
 		
-		Pool.getInstance().defineHistoricalMarking(newGene1);
-		Pool.getInstance().defineHistoricalMarking(newGene2);
+		pool.defineHistoricalMarking(newGene1);
+		pool.defineHistoricalMarking(newGene2);
 		
 		this.addGene(newGene1);
 		this.addGene(newGene2);

--- a/src/de/kaping/model/Neuron.java
+++ b/src/de/kaping/model/Neuron.java
@@ -31,48 +31,72 @@ public class Neuron {
 	private Type       type;
 	private List<Gene> incoming;
 	private double     value;
+	private int        innovation;
 
 	/**
 	 * Konstruktor
 	 */
 	public Neuron()
 	{
-		this(Type.UNDEFINED, 0., null);
+		this(Type.UNDEFINED, 0., null, -1);
 	}
 	
 	/**
-	 * Konstruktor, der den Typ des Neurons bereits festlegt
+	 * Konstruktor, der den Typ des Neurons bereits festlegt.
 	 * @param type Typ des Neurons
 	 */
 	public Neuron(Type type) 
 	{
-		this(type, 0., null);
+		this(type, 0., null, -1);
 	}
 
 	/**
-	 * Konstruktor, der sowohl Typ als auch Wert des Neurons festlegt
+	 * Konstruktor, der sowohl Typ als auch Wert des Neurons festlegt.
 	 * @param type Typ des Neurons
 	 * @param value Wert des Neurons
 	 */
 	public Neuron(Type type, double value)
 	{
-		this(type, value, null);
+		this(type, value, null, -1);
 	}
 	
 	/**
-	 * Konstruktor, der Typ, Wert und eingehende Verbindungen festlegt
+	 * Konstruktor, der Typ und Ursprung dieses Neurons festlegt.
+	 * @param type Type des Neurons
+	 * @param innovation Ursprung des Neurons
+	 */
+	public Neuron(Type type, int innovation)
+	{
+		this(type, 0., null, innovation);
+	}
+	
+	/**
+	 * Konstruktor, der Typ, Wert und eingehende Verbindungen festlegt.
 	 * @param type Typ des Neurons
 	 * @param value Wert des Neurons
 	 * @param inc Eingehende Verbindungen des Neurons
 	 */
 	public Neuron(Type type, double value, List<Gene> inc)
 	{
+		this(type, value, inc, -1);
+	}
+	
+	/**
+	 * Konstruktor, der bei Entstehung von Hiddennodes verwendet werden sollte.
+	 * @param type Typ des Neurons
+	 * @param value Wert des Neurons
+	 * @param inc Eingehende Verbindungen des Neurons
+	 * @param innovation Ursprung des Neurons
+	 */
+	public Neuron(Type type, double value, List<Gene> inc, int innovation)
+	{
 		super();
 		
 		log.trace("   Create new Neuron.");
 		
-		this.type     = type;
-		this.value    = value;
+		this.type       = type;
+		this.value      = value;
+		this.setInnovation(innovation);
 		
 		if(inc != null)
 			this.incoming = inc;
@@ -160,5 +184,24 @@ public class Neuron {
 	public void setType(Type type)
 	{
 		this.type = type;		
+	}
+
+	/**
+	 * Gibt den der Innovation dieses Neurons zurück. <code>-1</code> heißt, dass
+	 * das Neuron nicht durch die Aufteilung einer Verbindung entstanden ist.
+	 * @return Innovationsnummer der ursprünglichen Verbindung
+	 */
+	public int getInnovation()
+	{
+		return innovation;
+	}
+
+	/**
+	 * Setzt die Innovationsnummer dieses Neurons um.
+	 * @param innovation neue Innovationsnummer
+	 */
+	public void setInnovation(int innovation)
+	{
+		this.innovation = innovation;
 	}
 }

--- a/src/de/kaping/model/Pool.java
+++ b/src/de/kaping/model/Pool.java
@@ -34,6 +34,7 @@ public class Pool {
 	private int           historicalMarking;
 	
 	private List<Gene>    generationMarkings;
+	private List<Neuron>  newNeurons;
 	
 	/**
 	 * Konstruktor
@@ -49,6 +50,7 @@ public class Pool {
 		
 		this.species            = new ArrayList<Species>();
 		this.generationMarkings = new ArrayList<Gene>();
+		this.newNeurons         = new ArrayList<Neuron>();
 	}
 	
 	/**
@@ -67,28 +69,33 @@ public class Pool {
 	{
 		log.trace("ENTER "+this.getClass().getName()+".initializePool()");
 		List<Neuron> neurons = new ArrayList<Neuron>();
+		int inn = -1;
 		
 		/* Inputneuronen */
 		for(int i = 0; i < input; i++)
 		{
-			Neuron in = new Neuron(Type.INPUT, 1.);
+			Neuron in = new Neuron(Type.INPUT, 1., null, inn--);
 			neurons.add(in);
 		}
 		
 		/*Biasneuron */
-		Neuron bias = new Neuron(Type.BIAS, 1.);
+		Neuron bias = new Neuron(Type.BIAS, 1., null, inn--);
 		neurons.add(bias);
 		
 		/* Outputneuronen */
 		for(int i = 0; i < output; i++)
 		{
-			Neuron out = new Neuron(Type.OUTPUT, 0.);
+			Neuron out = new Neuron(Type.OUTPUT, 0., null, inn--);
 			neurons.add(out);
 		}
 		
 		for(int i = 0; i < Population; i++)
 		{
-			Genome genome = new Genome(neurons, true);
+			/* Erstelle eigene Liste für jedes Netzwerk */
+			List<Neuron> ownNeurons = new ArrayList<Neuron>();
+			for(Neuron n : neurons)
+				ownNeurons.add(n);
+			Genome genome = new Genome(ownNeurons, true);
 			this.addChildToSpecies(genome);
 		}
 		
@@ -188,6 +195,24 @@ public class Pool {
 	}
 	
 	/**
+	 * Gibt die Liste der neuen Neuronen dieser Generation zuück.
+	 * @return Liste der neuen Neuronen
+	 */
+	public List<Neuron> getNewNeurons()
+	{
+		return newNeurons;
+	}
+
+	/**
+	 * Setzt die Liste der neuen Neuronen dieser Generation.
+	 * @param newNeurons neue Liste von Neuronen
+	 */
+	public void setNewNeurons(List<Neuron> newNeurons)
+	{
+		this.newNeurons = newNeurons;
+	}
+	
+	/**
 	 * Erhöht die aktuelle Innovationsnummer, da eine neue Verbindung vorkommt.
 	 * @return neue Innovationsnummer
 	 */
@@ -216,6 +241,20 @@ public class Pool {
 	{
 		if (!generationMarkings.contains(gen))
 			return generationMarkings.add(gen);
+		return false;
+	}
+	
+	/**
+	 * Fügt ein neues Neuron in die Liste aller neuen Neuronen dieser Generation
+	 * ein.
+	 * @param neuron neues Neuron
+	 * @return Wahrheitswert, ob das Neuron hinzugefügt werden konnte
+	 */
+	public boolean addNewNeuron(Neuron neuron)
+	{
+		log.debug("   adding new Neuron to this generation!");
+		if (!newNeurons.contains(neuron))
+			return newNeurons.add(neuron);
 		return false;
 	}
 	
@@ -322,6 +361,8 @@ public class Pool {
 		
 		/* erstes Auftreten der Verbindung: neue Innovationsnummer und einfügen
 		 * in Liste der neuen Verbindungen dieser Generation. */
+		log.debug("   new Link: " + gen.getOrigin().getInnovation() + " zu " + 
+		          gen.getInto().getInnovation());
 		gen.setHistoricalMarking(this.newInnovation());
 		this.addNewGene(gen);
 	}
@@ -364,6 +405,7 @@ public class Pool {
 		for(Genome child : newGen)
 			this.addChildToSpecies(child);
 		
+		/* TODO: Reset newNeurons / generationMarkings */
 		this.generation++;
 		log.trace(" EXIT "+this.getClass().getName()+".newGeneration()");
 	}


### PR DESCRIPTION
Added Innovationnumber to Neuron and a list of all new Neurons to the
Population. Therefore changed mutateNode.

Fixed bug, where all geneomes would have the same neuron list.
